### PR TITLE
Update for API endpoint v3

### DIFF
--- a/api/Rest.php
+++ b/api/Rest.php
@@ -5,7 +5,7 @@ if(!defined("MEDIAWIKI"))
    die(1);
 }
 define("JIKI_USERAGENT","JIKI via MediaWiki");
-define("JIKI_REST_ENDPOINT","/rest/api/2/search");
+define("JIKI_REST_ENDPOINT","/rest/api/3/search/jql");
 define("JIKI_REST_EXPAND","names,renderedFields");
 define("JIKI_REST_FIELDS","summary,description,issuetype,fixVersions,status");
 define("JIKI_REST_MAXRESULTS","250");
@@ -40,12 +40,6 @@ class Rest
       $data["success"] = false;
       unset($data["total"],$data["data"]);
       return false;
-    }
-    if($response["total"]<=0)#no results
-    {
-      $data["success"] = true;
-      $data["total"] = 0;
-      return true;
     }
     $data["data"] = self::cleanData($response["issues"]);
     $data["total"] = sizeof($data["data"]);

--- a/view/Hypertext.php
+++ b/view/Hypertext.php
@@ -36,7 +36,7 @@ class Hypertext
     {
       # TODO: improve this sanitizing
       $issue["fields"]["summary"] = htmlspecialchars($issue["fields"]["summary"]);
-      $issue["fields"]["description"] = htmlspecialchars($issue["fields"]["description"]);
+      $issue["fields"]["description"] = htmlspecialchars($issue["renderedFields"]["description"]);
       $rIssue = "";#container for an issue
       $rIssue.= self::wrapField($format,"<img title=\"".$issue["fields"]["issuetype"]["name"].": ".$issue["fields"]["issuetype"]["description"]."\" src=\"".$issue["fields"]["issuetype"]["iconUrl"]."\"/>");
       $rIssue.= self::wrapField($format,"<strong>{$issue["key"]}</strong>");


### PR DESCRIPTION
The old search endpoint was deprecated on 31 October 2024 and removed 30 June 2025, see the changelog linked below.

In addition to switching the endpoint, the check for the total number of hits being zero (or negative) was removed; the `total` field does not appear to be included in the responses of the new API, and the missing array key is implicitly converted to null by PHP, which then evaluates as loosely equal to 0.

For the Hypertext output, the description is fixed to use the rendered field, instead of the raw field data which has an array of multiple entries.

* https://developer.atlassian.com/changelog/#CHANGE-2046
* https://developer.atlassian.com/changelog/#CHANGE-2598